### PR TITLE
Fix workout streak calculation logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,4 @@ A decentralized fitness platform that creates and manages personalized workout p
 - Level-based achievements
 - Prevention of duplicate profile creation
 - Enhanced achievement system with level milestones
+- Fixed streak calculation logic to properly handle consecutive workouts

--- a/contracts/fit_forge.clar
+++ b/contracts/fit_forge.clar
@@ -63,11 +63,11 @@
       (user-data (unwrap! (get-user-data tx-sender) err-not-found))
       (last-workout-height (get last-workout user-data))
       (current-streak (get current-streak user-data))
-      (new-streak (if (or 
-                      (is-eq last-workout-height u0)
-                      (is-eq (- block-height last-workout-height) u1))
-                    (+ current-streak u1)
-                    u1))
+      (new-streak (if (is-eq last-workout-height u0)
+                    u1
+                    (if (<= (- block-height last-workout-height) u1)
+                      (+ current-streak u1)
+                      u1)))
       (new-level (calculate-new-level (+ (get total-workouts user-data) u1)))
     )
     (try! (map-set Workouts workout-id {


### PR DESCRIPTION
This PR addresses an issue with the workout streak calculation logic in the FitForge contract. The previous implementation had a flaw that could incorrectly calculate streaks in certain edge cases.

Changes made:
1. Simplified the streak calculation logic in the log-workout function
2. Added proper handling for the first workout (when last_workout_height is 0)
3. Fixed the consecutive workout check to properly handle daily streaks

The new logic now:
- Sets streak to 1 for the first workout
- Increments streak if the new workout is within 1 block of the last workout
- Resets streak to 1 if the workout gap is more than 1 block

This change ensures more accurate streak tracking while maintaining all existing functionality and backwards compatibility.

Testing:
- All existing tests continue to pass
- Edge cases for streak calculations have been verified
- Achievements system continues to work as expected with the new streak logic